### PR TITLE
Restructure pipeline: per-doc folders, liteparse chunker, ParseResult persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+*.egg-info/
 **/*.csv
 **/*.xlsx
 **/*.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Search Anything
 
-A local-first RAG (Retrieval-Augmented Generation) system for indexing and querying documents — optimized for ML books and technical content.
+RAG for personal knowledge base.
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,24 +5,27 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "search-anything"
 version = "0.1.0"
-description = "Production-ready ML book RAG pipeline with switchable local/AWS backends"
+description = "Production-ready RAG pipeline with switchable methods and backends, designed for local and cloud deployment."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    # ── Parsing & chunking ──
+    # parsing/chunking
     "docling",
-    "liteparse",                # alternative local parser (native Rust core, built-in OCR)
-    "easyocr",                  # OCR engine for docling (scanned/mixed PDFs)
-    # ── Embedding & vector store (local) ──
-    "langchain-core",           # Document container at the Milvus boundary
+    "liteparse",
+    "easyocr",
+
+    # embedding/vectordb
+    "langchain-core",
     "langchain-huggingface",
     "langchain-milvus",
     "pymilvus",
     "sentence-transformers",
     "torch",
-    # ── LLM (local) ──
+    
+    # llm
     "anthropic",
-    # ── Misc ──
+
+    # data/io/obs
     "pandas",
     "python-dotenv",
     "watchdog",
@@ -38,15 +41,11 @@ aws = [
 search-anything = "main:main"
 
 [tool.setuptools]
-# main.py lives at the repo root (outside src/) as a top-level module so it can
-# back the console script while staying the `python main.py` entry point too.
 py-modules = ["main"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
 namespaces = true
 
-# Map only the rag package into src/ (not the whole root namespace), leaving the
-# root free for the top-level main module above.
 [tool.setuptools.package-dir]
 rag = "src/rag"

--- a/src/rag/backends/local/vectorstore.py
+++ b/src/rag/backends/local/vectorstore.py
@@ -65,7 +65,7 @@ class MilvusVectorStore:
                     "filename": chunk.filename,
                     "headings": chunk.headings,
                     "parent_headings": chunk.parent_headings,
-                    "text": chunk.text,  # raw text preserved for display
+                    "raw_text": chunk.text,  # raw text preserved for display
                 },
             ))
         return docs

--- a/src/rag/chunkers/docling_chunker.py
+++ b/src/rag/chunkers/docling_chunker.py
@@ -68,7 +68,7 @@ class DoclingChunker:
             headings_str = " => ".join(headings_list)
             parent_headings_str = " => ".join(headings_list[:-1]) if len(headings_list) > 1 else ""
 
-            enriched = self._chunker.contextualize(chunk=dl_chunk)
+            enriched = self._chunker.contextualize(chunk=dl_chunk) # prepend the full heading ancestry to the raw chunk text
 
             chunk = Chunk(
                 text=dl_chunk.text,
@@ -92,16 +92,29 @@ class DoclingChunker:
         """
         Return the DoclingDocument to chunk.
 
-        Prefers the live object from DoclingParser (no round-trip). Falls back
-        to re-parsing the markdown artifact when DoclingDocument is unavailable
-        (liteparse or plaintext paths).
+        Priority:
+          1. Live in-memory object from DoclingParser (no I/O).
+          2. Persisted docling.json — enables re-chunking without re-parsing.
+          3. Markdown fallback — re-parse converted.md via docling's markdown
+             backend (lower structural fidelity; last resort).
         """
         if parse_result.docling_document is not None:
             return parse_result.docling_document
 
+        if parse_result.doc_dir is not None:
+            docling_json = parse_result.doc_dir / "parse" / "docling.json"
+            if docling_json.exists():
+                import json
+                from docling_core.types.doc import DoclingDocument
+                data = json.loads(docling_json.read_text(encoding="utf-8"))
+                return DoclingDocument.model_validate(data)
+
         # Markdown fallback: re-parse via docling's markdown backend
         from docling.document_converter import DocumentConverter
-        from rag.config import DATA_DIR
-        stem = Path(parse_result.source_path).stem.replace(" ", "_").replace("-", "_").lower()
-        md_path = DATA_DIR / f"{stem}_converted.md"
+        if parse_result.doc_dir is not None:
+            md_path = parse_result.doc_dir / "parse" / "converted.md"
+        else:
+            from rag.config import DATA_DIR
+            stem = Path(parse_result.source_path).stem.replace(" ", "_").replace("-", "_").lower()
+            md_path = DATA_DIR / f"{stem}_converted.md"
         return DocumentConverter().convert(str(md_path)).document

--- a/src/rag/chunkers/liteparse_chunker.py
+++ b/src/rag/chunkers/liteparse_chunker.py
@@ -1,0 +1,116 @@
+import re
+from pathlib import Path
+
+from rag.core.schemas import Chunk, ParseResult
+from rag.config import CHUNK_MAX_TOKENS, CHUNK_TOKENIZER
+
+
+class LiteParseChunker:
+    """
+    Markdown-native chunker for LiteParseParser output. No docling dependency.
+
+    Pipeline:
+      1. Split on markdown headings (#, ##, ###...) — structural boundary pass
+      2. Token-aware split — break any section exceeding max_tokens by paragraph
+      3. Enrich — prepend full heading path to each chunk text for embedding
+
+    Enrichment mirrors docling's contextualize() output so the embedding input
+    format is consistent across both parser paths.
+    """
+
+    def __init__(self) -> None:
+        from transformers import AutoTokenizer
+        self._tokenizer = AutoTokenizer.from_pretrained(CHUNK_TOKENIZER)
+
+    def chunk(self, parse_result: ParseResult) -> tuple[list[Chunk], dict[str, str]]:
+        sections = _split_by_headings(parse_result.markdown)
+
+        chunks: list[Chunk] = []
+        parent_headings_text: dict[str, str] = {}
+
+        for heading_stack, text in sections:
+            headings_str = " => ".join(heading_stack)
+            parent_headings_str = " => ".join(heading_stack[:-1]) if len(heading_stack) > 1 else ""
+
+            for sub_text in self._split_by_tokens(text):
+                chunk = Chunk(
+                    text=sub_text,
+                    enriched_text=_contextualize(heading_stack, sub_text),
+                    headings=headings_str,
+                    parent_headings=parent_headings_str,
+                    content_hash=parse_result.content_hash,
+                    filename=parse_result.source_path.rsplit("/", 1)[-1],
+                )
+                chunks.append(chunk)
+
+            if parent_headings_str:
+                if parent_headings_str not in parent_headings_text:
+                    parent_headings_text[parent_headings_str] = text
+                else:
+                    parent_headings_text[parent_headings_str] += "\n" + text
+
+        return chunks, parent_headings_text
+
+    def _split_by_tokens(self, text: str) -> list[str]:
+        """Split text into token-bounded segments by paragraph boundaries."""
+        if len(self._tokenizer.encode(text)) <= CHUNK_MAX_TOKENS:
+            return [text]
+
+        paragraphs = [p.strip() for p in re.split(r"\n\n+", text) if p.strip()]
+        result: list[str] = []
+        current: list[str] = []
+        current_tokens = 0
+
+        for para in paragraphs:
+            para_tokens = len(self._tokenizer.encode(para))
+            if current_tokens + para_tokens > CHUNK_MAX_TOKENS and current:
+                result.append("\n\n".join(current))
+                current = [para]
+                current_tokens = para_tokens
+            else:
+                current.append(para)
+                current_tokens += para_tokens
+
+        if current:
+            result.append("\n\n".join(current))
+
+        return result or [text]
+
+
+def _split_by_headings(markdown: str) -> list[tuple[list[str], str]]:
+    """
+    Split markdown into (heading_stack, content) pairs.
+
+    heading_stack is the ordered list of ancestor headings at that point,
+    e.g. ["3 Supervised Learning", "3.2 Linear Regression"].
+    """
+    heading_re = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+    sections: list[tuple[list[str], str]] = []
+    heading_stack: list[str] = []
+    last_pos = 0
+
+    for match in heading_re.finditer(markdown):
+        level = len(match.group(1))
+        title = match.group(2).strip()
+
+        text_before = markdown[last_pos:match.start()].strip()
+        if text_before:
+            sections.append((list(heading_stack), text_before))
+
+        # Trim stack to parent level then push current heading
+        heading_stack = heading_stack[: level - 1]
+        heading_stack.append(title)
+        last_pos = match.end()
+
+    remaining = markdown[last_pos:].strip()
+    if remaining:
+        sections.append((list(heading_stack), remaining))
+
+    return [(stack, text) for stack, text in sections if text.strip()]
+
+
+def _contextualize(heading_stack: list[str], text: str) -> str:
+    """Prepend heading path to text, mirroring docling HybridChunker.contextualize()."""
+    if not heading_stack:
+        return text
+    return " => ".join(heading_stack) + "\n\n" + text

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -22,19 +22,15 @@ VECTOR_STORE_NAME = "book_a_snowflake_arctic_embed"
 MILVUS_URI        = str(VECTOR_STORE_DIR / f"{VECTOR_STORE_NAME}.db")
 
 # --- Parsing ---
-# Which local parser handles pdf/docx/pptx: "docling" (ML layout model) or
-# "liteparse" (fast native spatial parser). Lets you A/B parse quality.
-LOCAL_PARSER = os.getenv("LOCAL_PARSER", "docling")  # "docling" | "liteparse"
-# OCR recovers text from scanned pages / embedded images. force_full_page=False
-# means clean text-layer pages stay fast; only failed pages invoke OCR.
-PARSER_ENABLE_OCR = os.getenv("PARSER_ENABLE_OCR", "true").lower() == "true"
+LOCAL_PARSER = os.getenv("LOCAL_PARSER", "liteparse")  # "liteparse" | "docling"
+PARSER_ENABLE_OCR = os.getenv("PARSER_ENABLE_OCR", "true").lower() == "true" # force_full_page=False to avoid unnecessary OCR on clean PDFs
 # Below this many chars, a parse is treated as a likely scanned/empty doc.
 PARSER_MIN_CONTENT_LENGTH = 500
 # VLM image description (figures/diagrams). Slow + needs a VLM endpoint; later step.
 PARSER_ENABLE_IMAGE_DESCRIPTION = False
 
 # --- Chunking ---
-LOCAL_CHUNKER    = os.getenv("LOCAL_CHUNKER", "docling")  # "docling" | future strategies
+LOCAL_CHUNKER    = os.getenv("LOCAL_CHUNKER", "liteparse")  # "liteparse" | "docling"
 # Tokenizer that drives token counting + the model's max sequence length. Keep
 # this equal to the embedding model so chunk sizes match what actually gets embedded.
 CHUNK_TOKENIZER  = os.getenv("CHUNK_TOKENIZER", EMBED_MODEL_ID)

--- a/src/rag/core/schemas.py
+++ b/src/rag/core/schemas.py
@@ -1,19 +1,16 @@
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 
 @dataclass
 class ParseResult:
-    # Secondary, human-readable serialization. Audit artifact + the chunking
-    # input for parsers that produce no DoclingDocument (liteparse/plaintext).
     markdown: str
-    content_hash: str   # hex string (from docling or SHA-256)
+    content_hash: str   # SHA-256 hex string of the raw source file bytes
     source_path: str    # original file path or URL
     content_type: str   # "pdf", "docx", "web", "notebook", etc.
-    # PRIMARY output for the docling path: the structured semantic tree that
-    # chunking consumes directly. None for liteparse/plaintext paths.
-    # Typed as Any so core/ stays free of heavy docling imports.
-    docling_document: Any = None
+    docling_document: Any = None # docling structured parse result (semantic tree)
+    doc_dir: Path | None = None # per-document data folder for outputs
 
 
 @dataclass

--- a/src/rag/indexing.py
+++ b/src/rag/indexing.py
@@ -10,10 +10,6 @@ from rag.core.schemas import BookEntry
 from rag.config import BOOKS_DIR
 
 
-def _stem(source_path: str) -> str:
-    return Path(source_path).stem.replace(" ", "_").replace("-", "_").lower()
-
-
 def ingest_source(source: Path | str) -> dict:
     """Full ingestion pipeline for a single source. Idempotent."""
     backend = get_backend()
@@ -26,14 +22,12 @@ def ingest_source(source: Path | str) -> dict:
         print(f"[pipeline] Already ingested: {source.name} (hash={parse_result.content_hash[:10]}...)")
         return backend.registry.get(parse_result.content_hash)
 
-    stem = _stem(parse_result.source_path)
-
     print("[pipeline] Chunking and enriching...")
     chunks, parent_headings_text = chunking_step.chunk_and_enrich(parse_result)
 
     print(f"[pipeline] Summarizing {len(parent_headings_text)} parent heading groups...")
     summaries = asyncio.run(summarize_step.summarize_all(parent_headings_text, backend.llm))
-    summary_path = summarize_step.save_summaries_csv(summaries, stem)
+    summary_path = summarize_step.save_summaries_csv(summaries, parse_result.doc_dir)
 
     print(f"[pipeline] Embedding and storing {len(chunks)} chunks...")
     backend.vectorstore.store(chunks)

--- a/src/rag/parsers/docling_parser.py
+++ b/src/rag/parsers/docling_parser.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import re
 from pathlib import Path
 
@@ -65,12 +66,17 @@ class DoclingParser:
 
     def parse(self, source: Path | str) -> ParseResult:
         source = Path(source)
-        DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        # Hash the raw file bytes first — parser-agnostic, stable folder name
+        content_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+        doc_dir = DATA_DIR / f"{_stem(source)}_{content_hash[:12]}"
+        parse_dir = doc_dir / "parse"
+        parse_dir.mkdir(parents=True, exist_ok=True)
 
         result = self._converter.convert(str(source))
         md_text = _clean_markdown(_export_markdown(result.document))
 
-        # Validate BEFORE writing, so failed parses leave no orphan .md file behind
+        # Validate BEFORE writing, so failed parses leave no orphan files behind
         if len(md_text) < PARSER_MIN_CONTENT_LENGTH:
             raise ValueError(
                 f"Parsed content is suspiciously short ({len(md_text)} chars). "
@@ -78,27 +84,32 @@ class DoclingParser:
                 f"(PARSER_ENABLE_OCR=true) or pre-process with OCR."
             )
 
-        stem = _stem(source)
-        out_file = DATA_DIR / f"{stem}_converted.md"
-        out_file.write_text(md_text, encoding="utf-8")
-        print(f"[parser:docling] Saved markdown: {out_file}")
+        # converted.md — human-readable audit artifact; fallback chunking input
+        (parse_dir / "converted.md").write_text(md_text, encoding="utf-8")
+        print(f"[parser:docling] Saved markdown: {parse_dir / 'converted.md'}")
+
+        # docling.json — full structured document; enables re-chunking without re-parsing
+        (parse_dir / "docling.json").write_text(
+            json.dumps(result.document.export_to_dict()), encoding="utf-8"
+        )
+        print(f"[parser:docling] Saved docling document: {parse_dir / 'docling.json'}")
+
+        # parse_result.json — ParseResult metadata; ties all parse artifacts together
+        parse_result_meta = {
+            "content_hash": content_hash,
+            "source_path": str(source),
+            "content_type": source.suffix.lower().lstrip("."),
+        }
+        (parse_dir / "parse_result.json").write_text(
+            json.dumps(parse_result_meta, indent=2), encoding="utf-8"
+        )
+        print(f"[parser:docling] Saved parse result: {parse_dir / 'parse_result.json'}")
 
         return ParseResult(
             markdown=md_text,
-            content_hash=_content_hash(result.document, source),
+            content_hash=content_hash,
             source_path=str(source),
             content_type=source.suffix.lower().lstrip("."),
             docling_document=result.document,
+            doc_dir=doc_dir,
         )
-
-
-def _content_hash(document, source: Path) -> str:
-    """Prefer docling's document hash (hex string); fall back to SHA-256 of the file bytes."""
-    try:
-        raw_hash = document.export_to_dict().get("origin", {}).get("binary_hash")
-        if raw_hash:
-            # Docling returns a uint64 which can exceed int64 max; store as hex string
-            return hex(int(raw_hash))
-    except Exception:
-        pass
-    return hashlib.sha256(source.read_bytes()).hexdigest()

--- a/src/rag/parsers/liteparse_parser.py
+++ b/src/rag/parsers/liteparse_parser.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import re
 from pathlib import Path
 
@@ -41,12 +42,17 @@ class LiteParseParser:
 
     def parse(self, source: Path | str) -> ParseResult:
         source = Path(source)
-        DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+        # Hash the raw file bytes first — parser-agnostic, stable folder name
+        content_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+        doc_dir = DATA_DIR / f"{_stem(source)}_{content_hash[:12]}"
+        parse_dir = doc_dir / "parse"
+        parse_dir.mkdir(parents=True, exist_ok=True)
 
         result = self._parser.parse(str(source))
         md_text = _clean_markdown(result.text or "")
 
-        # Validate BEFORE writing, so failed parses leave no orphan .md file behind
+        # Validate BEFORE writing, so failed parses leave no orphan files behind
         if len(md_text) < PARSER_MIN_CONTENT_LENGTH:
             raise ValueError(
                 f"Parsed content is suspiciously short ({len(md_text)} chars). "
@@ -54,17 +60,26 @@ class LiteParseParser:
                 f"(PARSER_ENABLE_OCR=true)."
             )
 
-        stem = _stem(source)
-        out_file = DATA_DIR / f"{stem}_converted.md"
+        # converted.md — human-readable audit artifact; chunking input
+        out_file = parse_dir / "converted.md"
         out_file.write_text(md_text, encoding="utf-8")
         print(f"[parser:liteparse] Saved markdown: {out_file} ({result.num_pages} pages)")
 
-        # LiteParse exposes no document hash; hash the raw file bytes
-        content_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+        # parse_result.json — ParseResult metadata; ties all parse artifacts together
+        parse_result_meta = {
+            "content_hash": content_hash,
+            "source_path": str(source),
+            "content_type": source.suffix.lower().lstrip("."),
+        }
+        (parse_dir / "parse_result.json").write_text(
+            json.dumps(parse_result_meta, indent=2), encoding="utf-8"
+        )
+        print(f"[parser:liteparse] Saved parse result: {parse_dir / 'parse_result.json'}")
 
         return ParseResult(
             markdown=md_text,
             content_hash=content_hash,
             source_path=str(source),
             content_type=source.suffix.lower().lstrip("."),
+            doc_dir=doc_dir,
         )

--- a/src/rag/retrieval.py
+++ b/src/rag/retrieval.py
@@ -62,7 +62,7 @@ def retrieve(
             "headings": doc.metadata.get("headings", ""),
             "parent_headings": parent_headings,
             "summary": summary,
-            "page_content": doc.metadata.get("text") or doc.page_content,
+            "page_content": doc.metadata.get("raw_text") or doc.page_content,
         })
 
     return chunks

--- a/src/rag/steps/chunking.py
+++ b/src/rag/steps/chunking.py
@@ -6,6 +6,10 @@ Orchestration only — selects the configured chunker from rag.chunkers and
 routes the ParseResult to it. Adding a strategy = drop a file in chunkers/
 and add one dispatch line in _get_chunker().
 """
+import dataclasses
+import json
+from pathlib import Path
+
 from rag.core.schemas import Chunk, ParseResult
 from rag.config import LOCAL_CHUNKER
 
@@ -14,8 +18,19 @@ def _get_chunker():
     if LOCAL_CHUNKER == "docling":
         from rag.chunkers.docling_chunker import DoclingChunker
         return DoclingChunker()
-    from rag.chunkers.docling_chunker import DoclingChunker
-    return DoclingChunker()
+    from rag.chunkers.liteparse_chunker import LiteParseChunker
+    return LiteParseChunker()
+
+
+def save_chunks_jsonl(chunks: list[Chunk], doc_dir: Path) -> Path:
+    chunks_dir = doc_dir / "chunks"
+    chunks_dir.mkdir(parents=True, exist_ok=True)
+    out_file = chunks_dir / "chunks.jsonl"
+    with out_file.open("w", encoding="utf-8") as f:
+        for chunk in chunks:
+            f.write(json.dumps(dataclasses.asdict(chunk)) + "\n")
+    print(f"[chunking] Saved {len(chunks)} chunks: {out_file}")
+    return out_file
 
 
 def chunk_and_enrich(parse_result: ParseResult) -> tuple[list[Chunk], dict[str, str]]:
@@ -23,4 +38,6 @@ def chunk_and_enrich(parse_result: ParseResult) -> tuple[list[Chunk], dict[str, 
     chunker = _get_chunker()
     chunks, parent_headings_text = chunker.chunk(parse_result)
     print(f"[chunking] Created {len(chunks)} chunks, {len(parent_headings_text)} parent heading groups")
+    if parse_result.doc_dir is not None:
+        save_chunks_jsonl(chunks, parse_result.doc_dir)
     return chunks, parent_headings_text

--- a/src/rag/steps/parsing.py
+++ b/src/rag/steps/parsing.py
@@ -13,10 +13,11 @@ pluggable family that lives in `rag/parsers/`; this step decides which one
 to call.
 """
 import hashlib
+import json
 from pathlib import Path
 
 from rag.core.schemas import ParseResult
-from rag.config import LOCAL_PARSER
+from rag.config import LOCAL_PARSER, DATA_DIR
 
 # Extensions handled by the document parser family (docling / liteparse)
 _DOCUMENT_EXTENSIONS = {".pdf", ".docx", ".pptx"}
@@ -79,9 +80,23 @@ def _parse_plaintext(source: Path | str) -> ParseResult:
     source = Path(source)
     content = source.read_text(encoding="utf-8")
     content_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+    stem = source.stem.replace(" ", "_").replace("-", "_").lower()
+    doc_dir = DATA_DIR / f"{stem}_{content_hash[:12]}"
+    parse_dir = doc_dir / "parse"
+    parse_dir.mkdir(parents=True, exist_ok=True)
+    (parse_dir / "converted.md").write_text(content, encoding="utf-8")
+    parse_result_meta = {
+        "content_hash": content_hash,
+        "source_path": str(source),
+        "content_type": "text",
+    }
+    (parse_dir / "parse_result.json").write_text(
+        json.dumps(parse_result_meta, indent=2), encoding="utf-8"
+    )
     return ParseResult(
         markdown=content,
         content_hash=content_hash,
         source_path=str(source),
         content_type="text",
+        doc_dir=doc_dir,
     )

--- a/src/rag/steps/summarize.py
+++ b/src/rag/steps/summarize.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pandas as pd
 
 from rag.core.interfaces import LLM
-from rag.config import DATA_DIR, SUMMARY_SEMAPHORE, SUMMARY_MAX_TOKENS
+from rag.config import SUMMARY_SEMAPHORE, SUMMARY_MAX_TOKENS
 
 _SYSTEM = (
     "Summarize the book contents with condensed form in 3-4 sentences. "
@@ -41,8 +41,10 @@ async def summarize_all(
     return dict(results)
 
 
-def save_summaries_csv(summaries: dict[str, str], stem: str) -> Path:
-    out_file = DATA_DIR / f"{stem}_parent_headings_summary.csv"
+def save_summaries_csv(summaries: dict[str, str], doc_dir: Path) -> Path:
+    summaries_dir = doc_dir / "summaries"
+    summaries_dir.mkdir(parents=True, exist_ok=True)
+    out_file = summaries_dir / "parent_headings.csv"
     pd.DataFrame(
         summaries.items(), columns=["Parent Headings", "Summary"]
     ).to_csv(out_file, index=False)


### PR DESCRIPTION
## Summary
- Per-document data folders: `data/{stem}_{sha256[:12]}/parse|chunks|summaries/`
- `ParseResult` now persists all stage artifacts: `parse_result.json`, `converted.md`, `docling.json` (docling path), `chunks.jsonl`, `parent_headings.csv`
- New `LiteParseChunker`: fully markdown-native heading-aware splitting, zero docling dependency on the liteparse path
- liteparse set as default parser and chunker
- Fix Milvus reserved field collision: renamed metadata key `"text"` → `"raw_text"`
- Added `*.egg-info/` to `.gitignore`

## Test plan
- [ ] `python main.py ingest --paths <pdf>` completes with new folder structure under `data/`
- [ ] `parse/parse_result.json`, `parse/converted.md`, `chunks/chunks.jsonl`, `summaries/parent_headings.csv` all present after ingest
- [ ] `python main.py ask "<question>"` returns a valid answer
- [ ] Re-ingest same file is skipped (idempotent)
- [ ] `LOCAL_PARSER=docling` path still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)